### PR TITLE
implementation of size-based batching

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,24 +5,46 @@ MoveApps
 Github repository: https://github.com/PADAS/moveapps-integration
 
 ## Description
-Simple app to upload data from a move2 object to EarthRanger via API.
+Simple App to upload data from a `move2` object to EarthRanger via API.
 
 ## Documentation
-This app takes data from a move2 object, coerces to json via jsonlite packager, and iterates over the elements to push to EarthRanger via httr package. 
+This App takes data from a `move2` object, coerces to json via the `{jsonify}` package, and pushes it to EarthRanger in batches via the `{httr}` package. Each batch is limited to approximately 10MB, with an option to group observations by a specific attribute (e.g., study ID, track ID, cluster ID). Grouped observations will be kept together within the same batch during the upload process. 
+
+As a pass-through App, no changes are made to the output data. Therefore, it is strongly advised that users check the App's logs to confirm the success of the data upload.
 
 ### Input data
-move2 data
+`move2` data
 
 ### Output data
-move2 data (passthrough)
+`move2` data (pass-through)
 
 ### Artifacts
 none.
 
 ### Parameters 
-- server:  EarthRanger target server
-- api_key:  EarthRanger api key
-- batch_size:  number of records to push to EarthRanger at one time - batch_size of 0 causes all records to be pushed at once
-- event_type:  description of event to store in EarthRanger system
-- moveapp_id:  a user-supplied id to pass to EarthRanger
-- eventlist_fields:  Additional parameters from the move2 object to pass to EarthRanger as part of the event_details
+- **Target server for upload** [`server`]:  EarthRanger target server
+- **EarthRanger API key** [`api_key`]:  EarthRanger api key
+- **Grouping Column** [`grouping_col`]: Name of the column in the input data for grouping observations that should remain together in the same batch during data upload to EarthRanger. If set to NULL, the data will be split into batches as needed without respecting any groupings
+- **Event Type** [`event_type`]:  description of event to store in EarthRanger system
+- **MoveApp Identifier** [`moveapp_id`]:  a user-supplied id to pass to EarthRanger
+- **Fields to Pass to ER** [`eventlist_fields`]:  Additional parameters from the move2 object to pass to EarthRanger as part of the event_details
+
+
+### Most common errors
+
+When using parameter `grouping_col` for batching, please note:
+
+- The specified grouping column must be present in the event-level table of the input `move2` object. Otherwise, the App will terminate and return an error.
+
+- The batching process strictly adheres the specified grouping attribute, which means that a batch containing a large group may potentially exceed the intended 10MB batch size. Currently, transmissions to EarthRanger are effectively limited to a fixed 32MB per upload request. Therefore, if an upload fails due to an oversized batch, consider reducing the transmittable data by, e.g.: 
+
+  - Reducing the number of fields to pass to EarthRanger with `eventlist_fields` parameter;
+  
+  - Thinning the input data (i.e. downsample points) using the App [Thin Data by Time](https://www.moveapps.org/apps/browser/9c814c17-c61c-4cad-857d-2b44402a78b3);
+  
+  - Shortening the time window of the input data.
+
+
+
+ 
+ 

--- a/RFunction.R
+++ b/RFunction.R
@@ -1,107 +1,237 @@
 library('move2')
-library('jsonlite')
+library("jsonify")
 library('httr')
 library('sf')
 library('units')
+library("dplyr")
+library("tidyr")
+library("purrr")
+library("cli")
 
-## The parameter "data" is reserved for the data object passed on from the previous app
-
-# to display messages to the user in the log file of the App in MoveApps
-# one can use the function from the logger.R file:
-# logger.fatal(), logger.error(), logger.warn(), logger.info(), logger.debug(), logger.trace()
-
+#local helpers
 `%!in%` <- Negate(`%in%`)
 
-# Showcase injecting app setting (parameter `year`)
-rFunction = function(server,api_key,batch_size,event_type,moveapp_id,eventlist_fields,data, ...) {
+
+rFunction = function(data,
+                     server, 
+                     api_key,
+                     grouping_col = NULL,
+                     event_type,
+                     moveapp_id,
+                     eventlist_fields = NULL) {
+  
+  ## Initial set up ------------------------------------------------------------
 
   Sys.setenv(tz="UTC")
-  if (is.null(batch_size))
-  {
-    logger.info("Your batch size is not supplied. We use default 50 observations per API call")
-    batch_size <- 50
+  
+  # store original data to return as the app's output (i.e. making it a pass-through app)
+  data_orig <- data
+
+  # useful variables
+  tm_id_col <- mt_time_column(data)
+  trck_id_col <- mt_track_id_column(data)
+
+  # set maximum batch size in Megabytes
+  batch_max_Mb <- 10
+  
+  
+  ## Input Validation  ---------------------------------------------------------
+  
+  if(!is.null(grouping_col)){
+    if(!is.character(grouping_col) || length(grouping_col) > 1){
+      stop(paste0(
+        "`grouping_col` must be a character string of length 1. Please provide a valid ",
+        "column name to define groups for batch uploading to EarthRanger"
+      ))
+    } else if(grouping_col %!in% names(data) ){
+      stop(paste0(
+        "Specified column name '", grouping_col, "' must be present in the input data. ",
+        "Please ensure the grouping column for batch uploading is correctly specified in ",
+        "`grouping_col` argument"
+      ))
+    }
+  }
+
+  ## Pre-processing ------------------------------------------------------------
+  
+  logger.info("Pre-processing data")
+  
+  ### -- Add explicit grouping column, for internal use only 
+  if(is.null(grouping_col)){
+    # No specific groupings, i.e. rows are treated as independent
+    # Implemented by setting rowwise groups, to conform with remaining code
+    data$group_id <- 1:nrow(data)
+  }else{
+    data$group_id <- data[[grouping_col]]
   }
   
-  num_batches <- ifelse(batch_size==0,1,ceiling(nrow(data)/batch_size)) # determine number of batches needed for outer loop based on number of observations in the movestack
+  
+  ### -- Get event fields to include in upload
+  if(is.null(eventlist_fields) || (length(eventlist_fields) == 1 && nchar(eventlist_fields) == 0)){
+    event_fields <- names(data_orig)
+  }else {
+    # parse requested event list field names into a vector (allows comma or semicolon)
+    event_fields_parsed <- unlist(strsplit(eventlist_fields,",|;")) 
+    event_fields <- gsub("\\s+", "", event_fields_parsed)
+  }
 
   
-  # set up missing required columns
-  if("tagID" %!in% names(data))  data$tagID <- mt_track_id(data)
-  if("timestamp" %!in% names(data))  data$timestamp <- mt_time(data)
-  
+  ### -- Process expected lat lon columns
   if("location_long" %!in% names(data)){
+    
     if(st_is_longlat(data)){
       lon_lat <- st_coordinates(data)
     }else{
-      lon_lat <- data |> 
-        sf::st_transform(4326) |> 
+      lon_lat <- data |>
+        sf::st_transform(4326) |>
         sf::st_coordinates()
     }
-    data$location_long <- lon_lat[, 'X']
-    data$location_lat <- lon_lat[, 'Y']
-  } 
-  
-  status_codes <- numeric() # for capturing API response status codes
-
-  names(data) <- gsub(".","_",names(data),fixed=TRUE)
-  eventlist_fields_parsed <- unlist(strsplit(eventlist_fields,",|;")) # parse requested event list field names into a vector (allows comma or semicolon)
-  eventlist_fields_trimmed <- gsub("\\s+","",eventlist_fields_parsed) # remove spaces from parsed event list field names
-  eventlist_fields_filtered <- eventlist_fields_trimmed[eventlist_fields_trimmed %in% names(data)] # remove requested event list field names that are not in the dataset
-  if (length(eventlist_fields_filtered)==0) eventlist_fields_filtered <- names(data) # use all field names if no event list field names were supplied
-  eventlist_fields_filtered <- eventlist_fields_filtered[eventlist_fields_filtered != "geometry"]
-
-  for (i in 1:num_batches)
-  {
-    if (batch_size==0) batch <- data else batch <- data[((i-1)*batch_size+1):(min(i*batch_size,nrow(data))),]
-
-    for (j in 1:nrow(batch))
-    {
-      output <- list("device_id"=batch$tagID[j]
-                     ,"recorded_at"=format(batch$timestamp[j],"%Y-%m-%d %X%z")
-                     ,"location"=list("x"=batch$location_long[j],"y"=batch$location_lat[j]))
-      event_details = list()
-      for(field in eventlist_fields_filtered)
-      {
-        event_details[field] <- batch[[field]][j]
-        if(class(event_details[field]) == "units") events_details[field] <- drop_units(events_details[field])
-      }
-      output$event_details <- event_details
+    data$x <- lon_lat[, 'X']
+    data$y <- lon_lat[, 'Y']
     
-      output_json <- toJSON(output,pretty=FALSE,auto_unbox=TRUE) # convert list to json
-      output_json_str <- toString(output_json)
-      if (j==1)
-      {
-        all_output_json_str <- output_json_str
-      } else
-      {
-        all_output_json_str <- paste0(all_output_json_str,",",output_json_str)
-      }
-    }
-    er_json <- paste0("[",all_output_json_str,"]") # convert list to json and add square brackets to conform to ER API expected json format
-    url <- server
-    if(!grepl("\\?", server))
-    {
-      url <- paste0(url, "?")
-    }
-    else
-    {
-      url <- paste0(url, "&")  
-    }
-    url <- paste0(url, "event_type=", URLencode(event_type), "&moveapp_id=", URLencode(moveapp_id))
-    
-    logger.info(paste0("Posting data to ", url))
-    er_post <- POST(
-      url = url,
-      add_headers(apikey = api_key, 
-                  "accept" = "application/json",
-                  "content-type" = "application/json")
-      ,body = er_json
-    )
-    status_codes[i] <- status_code(er_post)
+  }else{
+    data <- dplyr::rename(data, x = location_long, y = location_lat)
   }
   
-  logger.info(paste0(sum(status_codes==200)," of ",num_batches," batches posted successfully to EarthRanger"))
-  result <- data
-  return(result)
-    
+  
+  ### -- Format key api request fields
+  data <- data |> 
+    data.frame() |> 
+    dplyr::mutate(
+      recorded_at = format(.data[[tm_id_col]], "%Y-%m-%d %X%z"),
+      # convert any columns of class integer64 to string, for safer json serialization
+      across(where(~inherits(.x, "integer64")), as.character)
+    ) |> 
+    dplyr::rename(any_of(c(device_id = trck_id_col))) |> 
+    units::drop_units()
+  
+  
+  ### -- Build the api endpoint url
+  if(!grepl("\\?", server)){
+    url <- paste0(server, "?")
+  } else{
+    url <- paste0(server, "&")  
+  }
+  
+  url <- paste0(url, "event_type=", URLencode(event_type), "&moveapp_id=", URLencode(moveapp_id))
+  
+  
+  
+  ### -- Prepare data, via nesting, for dataframe-based json coercion 
+  data_jsonble <- data |>
+    mutate(rowindex = dplyr::row_number()) |> # to enforce row-level nesting
+    tidyr::nest(
+      location = c(x, y),
+      event_details = any_of(event_fields),
+      .by = c(rowindex, group_id, device_id, recorded_at)
+    ) |>
+    dplyr::mutate(
+      location = lapply(location, as.list),
+      event_details = lapply(event_details, as.list)
+    )
+  
+  
+  
+  ## Define batches for uploading  ------------------------------------------------
+  
+  logger.info(paste0("Defining batches (maximum batch size: ", batch_max_Mb, "Mb)"))
+  
+  ### -- Workout batches, ensuring that each batch: 
+  ###  (i) shouldn't be greater than ~10Mb 
+  ###  (ii) keeps specified groups intact
+  
+  #### get a sample row of the json data
+  json_row <- data_jsonble |> 
+    dplyr::slice(1) |> 
+    dplyr::select(device_id, recorded_at, location, event_details) |> 
+    jsonify::to_json(unbox = TRUE, digits = 4, numeric_dates = FALSE) |> 
+    toString()
+  
+  #### get size of sample entry in bytes
+  row_json_bytes <- as.numeric(object.size(json_row))
+  
+  #### table with batch ids
+  batching_tbl <- data |> 
+    # rows per group
+    dplyr::count(group_id) |> 
+    # size per group 
+    dplyr::mutate(group_Mbs = (n * row_json_bytes)/1024^2) |> 
+    dplyr::arrange(group_Mbs) |> 
+    dplyr::mutate(
+      # cumulative size over groups
+      group_cum_Mbs = cumsum(group_Mbs),
+      # generate batches with no more than ~`batch_size_Mb`
+      batch_id = dplyr::dense_rank(group_cum_Mbs %/% batch_max_Mb)
+    )
+  
+  # merge batching info with jsonable data
+  data_jsonble <- data_jsonble |> 
+    dplyr::left_join(
+      batching_tbl |> dplyr::select(group_id, batch_id), 
+      by = "group_id"
+    )
+  
+  num_batches <- length(unique(batching_tbl$batch_id))
+  
+  
+  ## Perform batch requests to EarthRanger endpoint ----------------------------
+  
+  logger.info(paste0("Starting the upload of ", num_batches, " batch(es) of data to ER"))
+  
+  if(num_batches > 1){
+    if(is.null(grouping_col)){
+      logger.info(paste0(
+        "No grouping column specified, thus observations will be split arbitrarily ",
+        "between consecutive batches"))
+      }else{
+        logger.info(paste0(
+          "Batches comply with grouping column '", grouping_col, "', ensuring observations ",
+          "from the same group are posted together"))  
+      }  
+  }
+  
+  status_codes <- data_jsonble |> 
+    # split data by batch id
+    split(~batch_id) |> 
+    # iterate over list, each element performing a post request
+    purrr::map_int(
+      \(batch_dt){
+        
+        #browser()
+        
+        # coerce current batch to json
+        er_json_str <- batch_dt |> 
+          dplyr::select(device_id, recorded_at, location, event_details) |> 
+          jsonify::to_json(unbox = TRUE, numeric_dates = FALSE, digits = 4) |> 
+          toString()
+        
+        # post request
+        er_post <- POST(
+          url = url,
+          add_headers(
+            apikey = api_key,
+            "accept" = "application/json",
+            "content-type" = "application/json"),
+          body = er_json_str
+        )
+
+        # if present, report request error to the logger
+        if(http_error(er_post)){
+          logger.warn(paste0("    |- Error in POST request. Message:\n'", content(er_post)$message, "'"))
+        }
+
+        # return response status code
+        status_code(er_post)
+
+      }, .progress = list(
+        format = "Posted batch {cli::pb_current}/{cli::pb_total} {cli::pb_bar}| ETA: {cli::pb_eta}"
+      )
+    )
+  
+  logger.info(paste0(sum(status_codes==200), " of ", num_batches, " batches posted successfully to EarthRanger"))
+  
+  # return initial input data
+  return(data_orig)
+  
 }
+

--- a/RFunction_old.R
+++ b/RFunction_old.R
@@ -1,0 +1,109 @@
+library('move2')
+library('jsonlite')
+library('httr')
+library('sf')
+library('units')
+
+## The parameter "data" is reserved for the data object passed on from the previous app
+
+# to display messages to the user in the log file of the App in MoveApps
+# one can use the function from the logger.R file:
+# logger.fatal(), logger.error(), logger.warn(), logger.info(), logger.debug(), logger.trace()
+
+`%!in%` <- Negate(`%in%`)
+
+# Showcase injecting app setting (parameter `year`)
+rFunction_old = function(server,api_key,batch_size,event_type,moveapp_id,eventlist_fields,data, ...) {
+
+  Sys.setenv(tz="UTC")
+  if (is.null(batch_size))
+  {
+    logger.info("Your batch size is not supplied. We use default 50 observations per API call")
+    batch_size <- 50
+  }
+  
+  num_batches <- ifelse(batch_size==0,1,ceiling(nrow(data)/batch_size)) # determine number of batches needed for outer loop based on number of observations in the movestack
+
+  # set up missing required columns
+  if("tagID" %!in% names(data))  data$tagID <- mt_track_id(data)
+  if("timestamp" %!in% names(data))  data$timestamp <- mt_time(data)
+
+  if("location_long" %!in% names(data)){
+    if(st_is_longlat(data)){
+      lon_lat <- st_coordinates(data)
+    }else{
+      lon_lat <- data |>
+        sf::st_transform(4326) |>
+        sf::st_coordinates()
+    }
+    data$location_long <- lon_lat[, 'X']
+    data$location_lat <- lon_lat[, 'Y']
+  }
+  
+  status_codes <- numeric() # for capturing API response status codes
+
+  names(data) <- gsub(".","_",names(data),fixed=TRUE)
+  eventlist_fields_parsed <- unlist(strsplit(eventlist_fields,",|;")) # parse requested event list field names into a vector (allows comma or semicolon)
+  eventlist_fields_trimmed <- gsub("\\s+","",eventlist_fields_parsed) # remove spaces from parsed event list field names
+  eventlist_fields_filtered <- eventlist_fields_trimmed[eventlist_fields_trimmed %in% names(data)] # remove requested event list field names that are not in the dataset
+  if (length(eventlist_fields_filtered)==0) eventlist_fields_filtered <- names(data) # use all field names if no event list field names were supplied
+  eventlist_fields_filtered <- eventlist_fields_filtered[eventlist_fields_filtered != "geometry"]
+  
+  for (i in 1:num_batches)
+  {
+    if (batch_size==0) batch <- data else batch <- data[((i-1)*batch_size+1):(min(i*batch_size,nrow(data))),]
+
+    for (j in 1:nrow(batch))
+    {
+      output <- list("device_id"=batch$tagID[j]
+                     ,"recorded_at"=format(batch$timestamp[j],"%Y-%m-%d %X%z")
+                     ,"location"=list("x"=batch$location_long[j],"y"=batch$location_lat[j]))
+      event_details = list()
+      for(field in eventlist_fields_filtered)
+      {
+        event_details[field] <- batch[[field]][j]
+        if(class(event_details[field]) == "units") events_details[field] <- drop_units(events_details[field])
+      }
+      output$event_details <- event_details
+    
+      output_json <- toJSON(output,pretty=FALSE,auto_unbox=TRUE) # convert list to json
+      output_json_str <- toString(output_json)
+      if (j==1)
+      {
+        all_output_json_str <- output_json_str
+      } else
+      {
+        all_output_json_str <- paste0(all_output_json_str,",",output_json_str)
+      }
+    }
+    er_json <- paste0("[",all_output_json_str,"]") # convert list to json and add square brackets to conform to ER API expected json format
+    url <- server
+    if(!grepl("\\?", server))
+    {
+      url <- paste0(url, "?")
+    }
+    else
+    {
+      url <- paste0(url, "&")  
+    }
+    url <- paste0(url, "event_type=", URLencode(event_type), "&moveapp_id=", URLencode(moveapp_id))
+    
+    browser()
+    
+    logger.info(paste0("Posting data to ", url))
+    er_post <- POST(
+      url = url,
+      add_headers(apikey = api_key,
+                  "accept" = "application/json",
+                  "content-type" = "application/json")
+      ,body = er_json
+    )
+    
+    status_codes[i] <- status_code(er_post)
+  }
+  
+  logger.info(paste0(sum(status_codes==200)," of ",num_batches," batches posted successfully to EarthRanger"))
+  result <- data
+  return(result)
+    
+}

--- a/appspec.json
+++ b/appspec.json
@@ -2,7 +2,7 @@
   "settings": [
 	{
       "id": "server",
-      "name": "target server for upload",
+      "name": "Target server for upload",
       "description": "Choose the server for uploading",
       "defaultValue": "",
       "type": "STRING"
@@ -15,11 +15,11 @@
       "type": "STRING"
     },
 	{
-      "id": "batch_size",
-      "name": "Batch Size",
-      "description": "Number of observations per API call.  Default is 50.  Enter 0 to send all observations in a single batch.",
-      "defaultValue": 50,
-      "type": "DOUBLE"
+      "id": "grouping_col",
+      "name": "Grouping Column",
+      "description": "Name of the column in the input data for grouping observations that should remain together in the same batch during data upload to EarthRanger. If set to NULL, the data will be split into batches as needed without respecting any groupings",
+      "defaultValue": null,
+      "type": "STRING"
     },
 	{
       "id": "event_type",
@@ -39,7 +39,7 @@
       "id": "eventlist_fields",
       "name": "Fields to Pass to ER",
       "description": "If you would like to pass only certain movestack fields, list them here separated by comma or semicolon.  Leaving this blank will pass all fields.",
-      "defaultValue": "",
+      "defaultValue": null,
       "type": "STRING"
     }
   ],
@@ -49,13 +49,28 @@
         "name": "move2"
       },
       {
-        "name": "jsonlite"
+        "name": "jsonify"
       },
       {
         "name": "httr"
       },
       {
         "name": "sf"
+      },
+      {
+        "name": "units"
+      },
+      {
+        "name": "dplyr"
+      },
+      {
+        "name": "tidyr"
+      },
+      {
+        "name": "purrr"
+      },
+      {
+        "name": "cli"
       }
     ]
   },


### PR DESCRIPTION
Main changes:
- batches defined based on a maximum batch size (10MB)
- batch splitting respects integrity of a user-defined grouping column
- parameter `batch_size`  dropped
- Improved performance of JSON conversion via `{jsonify}` and data.frame coercion (instead of by-row iterations)


**PS:** Please feel free to edit the Readme and appspec.json files as see find fit!

