### PR TITLE
update to input type secret

### DIFF
--- a/appspec.json
+++ b/appspec.json
@@ -11,8 +11,8 @@
       "id": "api_key",
       "name": "EarthRanger API key",
       "description": "Provide your EarthRanger API key",
-      "defaultValue": "",
-      "type": "STRING"
+      "defaultValue": null,
+      "type": "SECRET"
     },
 	{
       "id": "grouping_col",


### PR DESCRIPTION
Hi @jeslefcourt, 
we have included a new input type "SECRET" for passwords, api-keys, etc. I made the necessary changes to include this new setting into your App. Using the input type secret, the passwords will not be printed as plain text in the logs and not be passed in when sharing a Workflow. 
We are currently working on creating a document that will contain all settings of all Apps of a Workflow. Given that this document can be easily shared and also appended to publications, it is for us of great importance that no sensitive information is contained.
Therefore we would like to ask you if you could resubmit your App with these changes as soon as you can. Once all Apps that contain plain text passwords are rebuilt, we can implement the creation of the settings summary document.
Thank you very much!
Best, Anne