### PR TITLE
Removed enforcement field names of lower-case conversion

### DIFF
--- a/RFunction.R
+++ b/RFunction.R
@@ -76,11 +76,6 @@ rFunction = function(data,
     event_fields <- gsub("\\s+", "", event_fields_parsed)
   }
   
-  # forcing names of all chosen fields to lower case, as per ER requirement
-  data <- dplyr::rename_with(data, tolower, .cols = dplyr::any_of(event_fields))
-  event_fields <- tolower(event_fields)
-  
-  
   ### -- Process expected lat lon columns
   if("location_long" %!in% names(data)){
     


### PR DESCRIPTION
Lower-case field name conversion was incompatible with earlier versions of EarthRanger’s cluster processing, causing existing MoveApps workflows to break when version 2025.10.2 was deployed.

This patch removes the lower-case conversion while retaining the handling of list-columns for JSON coercion (i.e. suppressing double-wrapped arrays). These changes are not expected to affect existing MoveApps workflows.