### PR TITLE
Added timeout to POST request

### DIFF
--- a/RFunction.R
+++ b/RFunction.R
@@ -223,6 +223,7 @@ rFunction = function(data,
             apikey = api_key,
             "accept" = "application/json",
             "content-type" = "application/json"),
+          httr::timeout(30*3600), # set max request time to 30mins
           body = er_json_str
         )
 


### PR DESCRIPTION
Added a 30-minute maximum request duration to the POST request - intended to reduce the incidence of timeout errors.